### PR TITLE
Fix ics date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased][unreleased]
+### Changed
+- The /api/calendar API now returns dates in YYYY-MM-DD format, the time part is removed (BC break!)
+
+### Fixed
+- Correct date in ICS files ([#31](https://github.com/metaodi/openerz/issues/31), thanks [Daniel Schregenberger](https://github.com/SuperBFG7))
 
 ## 0.10.0 - 2015-12-17
 ### Changed

--- a/lib/calendar.js
+++ b/lib/calendar.js
@@ -2,7 +2,7 @@
 
 var _ = require('underscore');
 var Calendar = require('icalendar');
-var Moment = require('moment-timezone');
+var Moment = require('moment');
 var content = require('./content');
 var config = require('./config');
 var trans = require('./translate').trans;
@@ -68,7 +68,7 @@ function convertToIcal(docs) {
         }
         vEvent.setDescription(trans.translate(calInfo[doc.type].description));
 
-        momDate = Moment(doc['date']).tz('Europe/Zurich');
+        momDate = Moment(doc['date']);
         vEvent.addProperty('DTSTART', momDate.toDate(), { VALUE: 'DATE' });
         vEvent.addProperty('DTEND', momDate.clone().add(1, 'days').toDate(), { VALUE: 'DATE' });
     });

--- a/lib/calendar.js
+++ b/lib/calendar.js
@@ -2,7 +2,7 @@
 
 var _ = require('underscore');
 var Calendar = require('icalendar');
-var Moment = require('moment');
+var Moment = require('moment-timezone');
 var content = require('./content');
 var config = require('./config');
 var trans = require('./translate').trans;
@@ -68,7 +68,7 @@ function convertToIcal(docs) {
         }
         vEvent.setDescription(trans.translate(calInfo[doc.type].description));
 
-        momDate = Moment(doc.date);
+        momDate = Moment(doc['date']).tz('Europe/Zurich');
         vEvent.addProperty('DTSTART', momDate.toDate(), { VALUE: 'DATE' });
         vEvent.addProperty('DTEND', momDate.clone().add(1, 'days').toDate(), { VALUE: 'DATE' });
     });

--- a/lib/db.js
+++ b/lib/db.js
@@ -27,8 +27,7 @@ function calendar(callback, params, sort, limit, offset) {
 
             // make sure the output is in the localtime zone
             _.map(docs, function(doc) {
-                var dateObj = Moment(doc['date']);
-                var zurichDate = dateObj.clone().tz('Europe/Zurich');
+                var zurichDate = Moment(doc['date']).tz('Europe/Zurich');
                 doc['date'] = zurichDate.format();
             });
             var result = {

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,5 +1,5 @@
 var mongojs = require('mongojs');
-var Moment = require('moment-timezone');
+var Moment = require('moment');
 var _ = require('underscore');
 
 exports.station = station;
@@ -27,8 +27,8 @@ function calendar(callback, params, sort, limit, offset) {
 
             // make sure the output is in the localtime zone
             _.map(docs, function(doc) {
-                var zurichDate = Moment(doc['date']).tz('Europe/Zurich');
-                doc['date'] = zurichDate.format();
+                var dateObj = Moment(doc['date']);
+                doc['date'] = dateObj.format('YYYY-MM-DD');
             });
             var result = {
                 '_metadata': {

--- a/lib/format.js
+++ b/lib/format.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var Moment = require('moment-timezone');
+var Moment = require('moment');
 var Fanci = require('fanci');
 
 exports.calendarEntry = calendarEntry;
@@ -8,8 +8,8 @@ exports.stationEntry = stationEntry;
 function calendarEntry(entry) {
     var dateFormat = function(value) {
         if (value) {
-            var zurichDate = Moment(value, '[XY,] DD. MMM YYYY', 'de').tz('Europe/Zurich');
-            return zurichDate.toDate();
+            var dateObj = Moment(value, '[XY,] DD. MMM YYYY', 'de');
+            return dateObj.startOf('day').toDate();
         }
         return value;
     };

--- a/lib/format.js
+++ b/lib/format.js
@@ -8,8 +8,7 @@ exports.stationEntry = stationEntry;
 function calendarEntry(entry) {
     var dateFormat = function(value) {
         if (value) {
-            var dateObj = Moment(value, '[XY,] DD. MMM YYYY', 'de');
-            var zurichDate = dateObj.clone().tz('Europe/Zurich');
+            var zurichDate = Moment(value, '[XY,] DD. MMM YYYY', 'de').tz('Europe/Zurich');
             return zurichDate.toDate();
         }
         return value;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "joi": "^7.0.1",
     "localize": "^0.4.7",
     "moment": "^2.8.4",
-    "moment-timezone": "^0.4.0",
     "mongojs": "^0.18.0",
     "nipple": "^2.5.2",
     "pm2": "~0.8.2",

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -319,7 +319,7 @@ describe('make sure the server is running (test.api)', function() {
                 .expect(200, {
                     "_metadata": {"total_count": 1},
                     "result": [{
-                        "date": "2016-01-04T00:00:00+01:00",
+                        "date": "2016-01-04",
                         "zip": 8038,
                         "type": "cardboard"
                     }]

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -1,3 +1,4 @@
+// jscs:disable maximumLineLength
 'use strict';
 
 var should = require('should'),
@@ -310,4 +311,54 @@ describe('make sure the server is running (test.api)', function() {
                 .expect(200, done);
         });
     });
+
+    describe('/api/calendar.json API is returning a correct entry', function() {
+        it('should return something', function(done) {
+            supertest
+                .get('/api/calendar.json?types=paper&types=cardboard&zip=8038&lang=de&start=2016-01-01&end=2016-01-05&sort=date')
+                .expect(200, {
+                    "_metadata": {"total_count": 1},
+                    "result": [{
+                        "date": "2016-01-04T00:00:00+01:00",
+                        "zip": 8038,
+                        "type": "cardboard"
+                    }]
+                }, done);
+        });
+    });
+
+    describe('/api/calendar.ics API is returning a correct entry', function() {
+        it('should return something', function(done) {
+            var expectedLines = [
+                "BEGIN:VCALENDAR",
+                "VERSION:2.0",
+                "PRODID:-//metaodi//openerz//EN",
+                "NAME:OpenERZ",
+                "X-WR-CALNAME:OpenERZ",
+                "DESCRIPTION:Entsorungskalender der Stadt Zürich (ERZ)",
+                "X-WR-CALDESC:Entsorungskalender der Stadt Zürich (ERZ)",
+                "TIMEZONE-ID:Europe/Zurich",
+                "TZID:Europe/Zurich",
+                "X-WR-TIMEZONE:Europe/Zurich",
+                "BEGIN:VEVENT",
+                "SUMMARY:Karton\\, PLZ: 8038",
+                "LOCATION:PLZ: 8038",
+                "DESCRIPTION:Kartonabfuhr-Kalender",
+                "DTSTART;VALUE=DATE:20160104",
+                "DTEND;VALUE=DATE:20160105",
+                "END:VEVENT",
+                "END:VCALENDAR"
+            ];
+            var expectedResult = expectedLines.join("\r\n") + "\r\n";
+            supertest
+                .get('/api/calendar.ics?types=paper&types=cardboard&zip=8038&lang=de&start=2016-01-01&end=2016-01-05&sort=date')
+                .expect(200)
+                .end(function(err, res) {
+                    should.not.exist(err);
+                    should.equal(res.text, expectedResult);
+                    done();
+                });
+        });
+    });
+
 });


### PR DESCRIPTION
All JavaScript date objects have a time and due to timezone differences
there was an error in the way the date was interpreted in the ICS.

Fixes #31 